### PR TITLE
Added an import for the show method from methods.

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 useDynLib(RProtoBuf)
 
 importFrom(methods, new)
+importFrom(methods, show)
 importFrom(utils, str, packageDescription)
 importFrom(stats, update)
 importFrom(tools, file_path_as_absolute)


### PR DESCRIPTION
Without this imported method, my package (and I believe any other) that imports `serialize_pb` and `unserialize_pb` from `RProtoBuf` gets a warning message when used with the `opencpu` package.  

```
> library(opencpu)
...
Loading required package: survival
Loading required package: graphics
Loading required package: stats
Warning message:
no function found corresponding to methods exports from ‘RProtoBuf’ for: ‘show’ 
OpenCPU started.
[httpuv] http://localhost:3301/ocpu
OpenCPU single-user server ready.
```
